### PR TITLE
Added additional config/scripting abilities through /etc/default

### DIFF
--- a/steam-session/Makefile
+++ b/steam-session/Makefile
@@ -12,6 +12,7 @@ install:
 	mkdir -p $(DESTDIR)$(PREFIX)/share/unity-greeter
 	mkdir -p $(DESTDIR)$(PREFIX)/share/xsessions
 	install -m755 steam-de $(DESTDIR)$(PREFIX)/bin
+	install -m644 steam-de.default $(DESTDIR)/etc/steam-de
 	install -m644 custom_steam-bigpicture_badge.png $(DESTDIR)$(PREFIX)/share/unity-greeter
 	install -m644 steam-bigpicture.desktop $(DESTDIR)$(PREFIX)/share/xsessions
 

--- a/steam-session/steam-de
+++ b/steam-session/steam-de
@@ -78,6 +78,7 @@ PID=$!
 # Start basic window manager and video settings
 which nvidia-settings && nvidia-settings -l 
 which gnome-settings-daemon && gnome-settings-daemon &
+source /etc/default/steam-de
 exec openbox
 
 while ! check_steam_window

--- a/steam-session/steam-de.default
+++ b/steam-session/steam-de.default
@@ -1,0 +1,13 @@
+#
+# This script is sourced from the steam-de wrapper (by default in
+# /usr/bin/steam-de). Add here any calls and settings you need done before the
+# openbox session is spawned.
+#
+# For example, if you have multiple monitors and want to play using just one,
+# and the proper one, you can set that up using xrandr:
+#xrandr --output VGA-0 --off --output DVI-I-1 --auto
+
+# You can also configure xinput, for example, and adjust your mouse to disable
+# acceleration, if you want so.
+#xinput set-prop 8 'Device Accel Profile' -1
+#xinput set-prop 8 'Device Accel Velocity Scaling' 1


### PR DESCRIPTION
Managing multiple monitors did not work for me with nvidia-settings, steam would launch in the wrong monitor, always, so I devised this to force various X settings right before openbox is exec'd. Also other options like mouse accel, etc...

Basically, the main script now sources from /etc/default/steam-de where the user can put whatever customization they want.